### PR TITLE
Finally get the response headers.

### DIFF
--- a/latency_monitoring/.gitignore
+++ b/latency_monitoring/.gitignore
@@ -1,3 +1,3 @@
-istio-*
+istio-1.8.0
 *.log
 __pycache__/

--- a/latency_monitoring/fault_testing.py
+++ b/latency_monitoring/fault_testing.py
@@ -289,6 +289,7 @@ def build_filter(filter_dir, filter_name):
 def undeploy_filter(filter_name):
     cmd = f"{WASME_BIN} undeploy istio {filter_name}:{FILTER_TAG} "
     cmd += f"–provider=istio --id {FILTER_ID} "
+    # cmd += "--labels \"app=reviews\" "
     result = util.exec_process(cmd)
     if result != util.EXIT_SUCCESS:
         return result
@@ -300,6 +301,7 @@ def deploy_filter(filter_name):
     # first deploy with the unidirectional wasme binary
     cmd = f"{WASME_BIN} deploy istio {filter_name}:{FILTER_TAG} "
     cmd += f"–provider=istio --id {FILTER_ID} "
+    # cmd += "--labels \"app=reviews\" "
     result = util.exec_process(cmd)
     if result != util.EXIT_SUCCESS:
         return result
@@ -309,7 +311,7 @@ def deploy_filter(filter_name):
     # now redeploy with the patched bidirectional wasme
     cmd = f"{PATCHED_WASME_BIN} deploy istio {filter_name}:{FILTER_TAG} "
     cmd += f"–provider=istio --id {FILTER_ID} "
-    # cmd += "--config \'{\"name\": \"always_set_request_id_in_response\",\"value\": \"true\"}\' "
+    # cmd += "--labels \"app=reviews\" "
     result = util.exec_process(cmd)
     bookinfo_wait()
 

--- a/latency_monitoring/yaml_crds/istio-config-gcp.yaml
+++ b/latency_monitoring/yaml_crds/istio-config-gcp.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: custom-protocol
+  namespace: default  # as defined in meshConfig resource.
+spec:
+  configPatches:
+  - applyTo: NETWORK_FILTER  # http connection manager is a filter in Envoy
+    match:
+      # context omitted so that this applies to both sidecars and gateways
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.http_connection_manager"
+    patch:
+      operation: MERGE
+      value:
+        typed_config:
+          "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager"
+          generate_request_id: true
+          preserve_external_request_id: true

--- a/latency_monitoring/yaml_crds/istio-config.yaml
+++ b/latency_monitoring/yaml_crds/istio-config.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: custom-protocol
+  namespace: default  # as defined in meshConfig resource.
+spec:
+  configPatches:
+  - applyTo: NETWORK_FILTER  # http connection manager is a filter in Envoy
+    match:
+      # context omitted so that this applies to both sidecars and gateways
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.http_connection_manager"
+    patch:
+      operation: MERGE
+      value:
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+          use_remote_address: false
+          generate_request_id: true
+          preserve_external_request_id: true
+          always_set_request_id_in_response: true

--- a/latency_monitoring/yaml_crds/istio-route-config.yaml
+++ b/latency_monitoring/yaml_crds/istio-route-config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: custom-protocol
+  namespace: default  # as defined in meshConfig resource.
+spec:
+  configPatches:
+  - applyTo: ROUTE_CONFIGURATION
+    match:
+      context: ANY
+      # context omitted so that this applies to both sidecars and gateways
+      route:
+        destination:
+          host: "*"
+    patch:
+      operation: MERGE
+      value:
+          response_headers_to_add:
+          - header:
+              key: x-request-id
+              value: "%REQ(x-request-id)%"


### PR DESCRIPTION
By attaching the istio-route-config.yaml in the yaml folder we can get request-ids on responses. This needs lot of refinement but at least we have something now.